### PR TITLE
Map A8_UNORM with swizzle

### DIFF
--- a/UnleashedRecomp/gpu/rhi/plume_render_interface_types.h
+++ b/UnleashedRecomp/gpu/rhi/plume_render_interface_types.h
@@ -154,8 +154,7 @@ namespace plume {
         BC6H_SF16,
         BC7_TYPELESS,
         BC7_UNORM,
-        BC7_UNORM_SRGB,
-        A8_UNORM,
+        BC7_UNORM_SRGB
     };
 
     enum class RenderTextureDimension {
@@ -640,7 +639,6 @@ namespace plume {
         case RenderFormat::R8_UINT:
         case RenderFormat::R8_SNORM:
         case RenderFormat::R8_SINT:
-        case RenderFormat::A8_UNORM:
             return 1;
         case RenderFormat::BC1_TYPELESS:
         case RenderFormat::BC1_UNORM:

--- a/UnleashedRecomp/gpu/rhi/plume_vulkan.cpp
+++ b/UnleashedRecomp/gpu/rhi/plume_vulkan.cpp
@@ -237,8 +237,6 @@ namespace plume {
             return VK_FORMAT_BC7_UNORM_BLOCK;
         case RenderFormat::BC7_UNORM_SRGB:
             return VK_FORMAT_BC7_SRGB_BLOCK;
-        case RenderFormat::A8_UNORM:
-            return VK_FORMAT_A8_UNORM_KHR;
         default:
             assert(false && "Unknown format.");
             return VK_FORMAT_UNDEFINED;

--- a/UnleashedRecomp/gpu/video.cpp
+++ b/UnleashedRecomp/gpu/video.cpp
@@ -5489,6 +5489,7 @@ static RenderFormat ConvertDXGIFormat(ddspp::DXGIFormat format)
     case ddspp::R8_TYPELESS:
         return RenderFormat::R8_TYPELESS;
     case ddspp::R8_UNORM:
+    case ddspp::A8_UNORM:
         return RenderFormat::R8_UNORM;
     case ddspp::R8_UINT:
         return RenderFormat::R8_UINT;
@@ -5538,8 +5539,6 @@ static RenderFormat ConvertDXGIFormat(ddspp::DXGIFormat format)
         return RenderFormat::BC7_UNORM;
     case ddspp::BC7_UNORM_SRGB:
         return RenderFormat::BC7_UNORM_SRGB;
-    case ddspp::A8_UNORM:
-        return RenderFormat::A8_UNORM;
     default:
         printf("format: %x\n", format);
         assert(false && "Unsupported format from DDS.");
@@ -5570,6 +5569,13 @@ static bool LoadTexture(GuestTexture& texture, const uint8_t* data, size_t dataS
         viewDesc.format = desc.format;
         viewDesc.dimension = ConvertTextureViewDimension(ddsDesc.type);
         viewDesc.mipLevels = ddsDesc.numMips;
+
+        if (ddsDesc.format == ddspp::A8_UNORM)
+        {
+            // Map A8_UNORM to R8_UNORM for compatability
+            componentMapping = RenderComponentMapping(RenderSwizzle::ZERO, RenderSwizzle::ZERO, RenderSwizzle::ZERO, RenderSwizzle::R);
+        }
+
         viewDesc.componentMapping = componentMapping;
         texture.textureView = texture.texture->createTextureView(viewDesc);
         texture.descriptorIndex = g_textureDescriptorAllocator.allocate();


### PR DESCRIPTION
The way this was implemented was not complete for other render APIs and was also violating Vulkan spec. `VK_FORMAT_A8_UNORM_KHR` can only be used when `VK_KHR_maintenance5` is enabled, or when using Vulkan 1.4. 

Component swizzling can be implemented across all APIs through Plume and is supported on all devices.