### PR TITLE
Add support for array textures

### DIFF
--- a/UnleashedRecomp/gpu/video.cpp
+++ b/UnleashedRecomp/gpu/video.cpp
@@ -3025,8 +3025,10 @@ static GuestTexture* CreateTexture(uint32_t width, uint32_t height, uint32_t dep
 
     if (texture->type == ResourceType::ArrayTexture) {
         desc.arraySize = depth;
+        desc.depth = 1;
     } else {
         desc.depth = depth;
+        desc.arraySize = 1;
     }
 
     if (desc.format == RenderFormat::D32_FLOAT)

--- a/UnleashedRecomp/gpu/video.cpp
+++ b/UnleashedRecomp/gpu/video.cpp
@@ -2999,16 +2999,35 @@ static RenderFormat ConvertFormat(uint32_t format)
 
 static GuestTexture* CreateTexture(uint32_t width, uint32_t height, uint32_t depth, uint32_t levels, uint32_t usage, uint32_t format, uint32_t pool, uint32_t type) 
 {
-    const auto texture = g_userHeap.AllocPhysical<GuestTexture>(type == 17 ? ResourceType::VolumeTexture : ResourceType::Texture);
+    ResourceType resourceType;
+
+    switch (type)
+    {
+    case 17:
+        resourceType = ResourceType::VolumeTexture;
+        break;
+    case 19:
+        resourceType = ResourceType::ArrayTexture;
+        break;
+    default:
+        resourceType = ResourceType::Texture;
+        break;
+    }
+
+    const auto texture = g_userHeap.AllocPhysical<GuestTexture>(resourceType);
 
     RenderTextureDesc desc;
     desc.dimension = texture->type == ResourceType::VolumeTexture ? RenderTextureDimension::TEXTURE_3D : RenderTextureDimension::TEXTURE_2D;
     desc.width = width;
     desc.height = height;
-    desc.depth = depth;
     desc.mipLevels = levels;
-    desc.arraySize = 1;
     desc.format = ConvertFormat(format);
+
+    if (texture->type == ResourceType::ArrayTexture) {
+        desc.arraySize = depth;
+    } else {
+        desc.depth = depth;
+    }
 
     if (desc.format == RenderFormat::D32_FLOAT)
         desc.flags = RenderTextureFlag::DEPTH_TARGET;

--- a/UnleashedRecomp/gpu/video.cpp
+++ b/UnleashedRecomp/gpu/video.cpp
@@ -7804,6 +7804,8 @@ GUEST_FUNCTION_HOOK(sub_82542050, SetRenderState<D3DRS_COLORWRITEENABLE>);
 
 int GetType(GuestResource* resource) {
     if (resource->type == ResourceType::Texture) return 3;
+    if (resource->type == ResourceType::VolumeTexture) return 17;
+    if (resource->type == ResourceType::ArrayTexture) return 19;
     LOGF_WARNING("unknown resource type {:d}!", (int32_t)resource->type);
     __builtin_trap();
     return 0;

--- a/UnleashedRecomp/gpu/video.h
+++ b/UnleashedRecomp/gpu/video.h
@@ -76,6 +76,7 @@ enum class ResourceType
 {
     Texture,
     VolumeTexture,
+    ArrayTexture,
     VertexBuffer,
     IndexBuffer,
     RenderTarget,


### PR DESCRIPTION
Shadows are created as a Texture2D Array of cascades, currently these are being incorrectly created as a volume texture.