### PR TITLE
Set error code when XCreateFileA fails on non-Windows

### DIFF
--- a/MarathonRecomp/kernel/io/file_system.cpp
+++ b/MarathonRecomp/kernel/io/file_system.cpp
@@ -113,6 +113,20 @@ FileHandle* XCreateFileA
     {
 #ifdef _WIN32
         GuestThread::SetLastError(GetLastError());
+#else
+        switch (errno)
+        {
+        case EACCES:
+            GuestThread::SetLastError(ERROR_ACCESS_DENIED);
+            break;
+        case EEXIST:
+            GuestThread::SetLastError(ERROR_FILE_EXISTS);
+            break;
+        case ENOENT:
+        default: // Use ERROR_PATH_NOT_FOUND as a catch-all for other errors.
+            GuestThread::SetLastError(ERROR_PATH_NOT_FOUND);
+            break;
+        }
 #endif
         return GetInvalidKernelObject<FileHandle>();
     }

--- a/MarathonRecomp/kernel/xdm.h
+++ b/MarathonRecomp/kernel/xdm.h
@@ -38,6 +38,8 @@
 #define ERROR_NO_SUCH_USER         0x525
 #define ERROR_SUCCESS              0x0
 #define ERROR_PATH_NOT_FOUND       0x3
+#define ERROR_ACCESS_DENIED        0x5
+#define ERROR_FILE_EXISTS          0x50
 #define ERROR_BAD_ARGUMENTS        0xA0
 #define ERROR_DEVICE_NOT_CONNECTED 0x48F
 #define PAGE_READWRITE             0x04


### PR DESCRIPTION
Add logic to call `SetLastError` on non-Windows, translating from the `errno`. Some known possible error codes here are translated from their POSIX equivalent, and `ERROR_PATH_NOT_FOUND` is used as a fallback for any others.

Fixes crash in some cutscenes when game tries to open an `xma` file that does not exist.