### PR TITLE
Apply half pixel offset in the vertex shader.

### DIFF
--- a/MarathonRecomp/gpu/shader/csd_no_tex_vs.hlsl
+++ b/MarathonRecomp/gpu/shader/csd_no_tex_vs.hlsl
@@ -43,7 +43,7 @@ void main(
 	out float4 oColor0 : COLOR0,
 	out float4 oColor1 : COLOR1)
 {
-    oPos.xy = (iPosition0.xy - 0.5) * g_ViewportSize.zw * float2(2.0, -2.0) + float2(-1.0, 1.0);
+    oPos.xy = iPosition0.xy * g_ViewportSize.zw * float2(2.0, -2.0) + float2(-1.0, 1.0);
     oPos.z = g_Z.x;
     oPos.w = 1.0;
     oTexCoord0 = iColor0.wxyz;

--- a/MarathonRecomp/gpu/shader/csd_vs.hlsl
+++ b/MarathonRecomp/gpu/shader/csd_vs.hlsl
@@ -44,7 +44,7 @@ void main(
 	out float4 oColor0 : COLOR0,
 	out float4 oColor1 : COLOR1)
 {    
-    oPos.xy = (iPosition0.xy - 0.5) * g_ViewportSize.zw * float2(2.0, -2.0) + float2(-1.0, 1.0);
+    oPos.xy = iPosition0.xy * g_ViewportSize.zw * float2(2.0, -2.0) + float2(-1.0, 1.0);
     oPos.z = g_Z.x;
     oPos.w = 1.0;
     oTexCoord0 = iColor0.wxyz;

--- a/MarathonRecomp/gpu/shader/movie_vs.hlsl
+++ b/MarathonRecomp/gpu/shader/movie_vs.hlsl
@@ -4,6 +4,7 @@ Interpolators main(in VertexShaderInput In)
 {
     Interpolators Out;
     Out.ProjPos = In.ObjPos;
+    Out.ProjPos.xy += g_HalfPixelOffset * Out.ProjPos.w;
     Out.UV = In.UV;
     return Out;
 }

--- a/MarathonRecomp/gpu/video.cpp
+++ b/MarathonRecomp/gpu/video.cpp
@@ -166,6 +166,8 @@ struct SharedConstants
     uint32_t samplerIndices[16]{};
     uint32_t booleans{};
     uint32_t swappedTexcoords{};
+    float halfPixelOffsetX{};
+    float halfPixelOffsetY{};
     float alphaThreshold{};
 };
 
@@ -3192,8 +3194,6 @@ static void FlushViewport()
     if (g_dirtyStates.viewport)
     {
         auto viewport = g_viewport;
-        viewport.x += 0.5f;
-        viewport.y += 0.5f;
 
         // if (viewport.minDepth > viewport.maxDepth)
         //     std::swap(viewport.minDepth, viewport.maxDepth);
@@ -3622,6 +3622,12 @@ static void SetFramebuffer(GuestSurface* renderTarget, GuestSurface* depthStenci
         {
             commandList->setFramebuffer(nullptr);
             g_framebuffer = nullptr;
+        }
+
+        if (g_framebuffer != nullptr)
+        {
+            SetDirtyValue(g_dirtyStates.sharedConstants, g_sharedConstants.halfPixelOffsetX, 1.0f / float(g_framebuffer->getWidth()));
+            SetDirtyValue(g_dirtyStates.sharedConstants, g_sharedConstants.halfPixelOffsetY, -1.0f / float(g_framebuffer->getHeight()));
         }
 
         g_dirtyStates.renderTargetAndDepthStencil = settingForClear;


### PR DESCRIPTION
Cherry-pick in the commit for half-pixel offset in the vertex shader from Unleashed.

Fixes:
* Half-pixel offset in XenosRecomp not working.
* Alpha ref not working because the shared constants offset in XenosRecomp is wrong without this.

Requires https://github.com/ga2mer/XenosRecomp/pull/1