### PR TITLE
Restore pixel constants dirty state handling.

### DIFF
--- a/MarathonRecomp/gpu/video.cpp
+++ b/MarathonRecomp/gpu/video.cpp
@@ -4313,8 +4313,8 @@ static void FlushRenderStateForMainThread(GuestDevice* device, LocalRenderComman
     dirtyFlags = device->dirtyFlags[1].get();
     if (dirtyFlags != 0)
     {
-        int startRegister = std::min(56, std::countr_zero(dirtyFlags));
-        int endRegister = std::min(56, 64 - std::countl_zero(dirtyFlags));
+        int startRegister = std::countl_zero(dirtyFlags);
+        int endRegister = std::min(56, 64 - std::countr_zero(dirtyFlags));
 
         uint32_t index = startRegister * 16;
         uint32_t size = (endRegister - startRegister) * 64;
@@ -8073,7 +8073,7 @@ uint32_t BeginRingBig(GuestDevice* device, int32_t count) {
         g_ringBuffer = g_memory.MapVirtual(g_userHeap.AllocPhysical((size_t)0x1000, 16));
     }
     device->dirtyFlags[0] = ~0ull; // copy all
-    device->dirtyFlags[1] = ~0ull;
+    device->dirtyFlags[1] = ~0xFFull;
     return g_ringBuffer;
 }
 


### PR DESCRIPTION
Checked the logic for this and the bit order was correct originally. Also don't set dirty flags for pixel constant registers that don't exist in `BeginRingBig`.

This re-breaks the Kingdom Valley pillar and Radical Train door colors again, but it seems there's something else wrong. You can actually also get the correct result from here by modifying the dirty flag set in `BeginRingBig` to *not* mark the first few pixel constant registers as dirty, although that breaks other things that setting the flags here works around.