### PR TITLE
Fix validation error for copy pipeline attachment format mismatch.

### DIFF
--- a/MarathonRecomp/gpu/video.cpp
+++ b/MarathonRecomp/gpu/video.cpp
@@ -3640,7 +3640,7 @@ static void ExecutePendingStretchRectCommands(GuestSurface* renderTarget, GuestS
                         }
                         else
                         {
-                            auto& copyColorPipeline = g_copyColorPipelines[surface->format];
+                            auto& copyColorPipeline = g_copyColorPipelines[texture->format];
                             if (copyColorPipeline == nullptr)
                             {
                                 RenderGraphicsPipelineDesc desc;


### PR DESCRIPTION
Color copy pipelines are different depending on destination texture format, not surface format, so key the pipeline map appropriately.

Fixes validation error on mismatch between R8G8B8A8 and R16G16B16A16 formats between pipeline and render pass.