### PR TITLE
Fix title buttons patch.

### DIFF
--- a/MarathonRecomp/api/Sonicteam/TitleTask.h
+++ b/MarathonRecomp/api/Sonicteam/TitleTask.h
@@ -8,7 +8,7 @@ namespace Sonicteam
     class TitleTask : public Sonicteam::SoX::Engine::Task
     {
     public:
-        MARATHON_INSERT_PADDING(0x0C);
+        MARATHON_INSERT_PADDING(0x10);
         be<uint32_t> m_SelectedIndex;
     };
 }


### PR DESCRIPTION
Offset of `m_SelectedIndex` was slightly off from before, leading to the incorrect button being selected.