### PR TITLE
Fix depth-only rendering.

### DIFF
--- a/MarathonRecomp/gpu/video.cpp
+++ b/MarathonRecomp/gpu/video.cpp
@@ -3474,8 +3474,7 @@ static void SetDefaultViewport(GuestDevice* device, GuestSurface* surface)
 
 static void SetRenderTarget(GuestDevice* device, uint32_t index, GuestSurface* renderTarget) 
 {
-    // printf("SetRenderTarget %x %d %x\n", device, index, renderTarget);
-    if (renderTarget != nullptr)
+    if (index == 0)
     {
         RenderCommand cmd;
         cmd.type = RenderCommandType::SetRenderTarget;
@@ -3483,6 +3482,11 @@ static void SetRenderTarget(GuestDevice* device, uint32_t index, GuestSurface* r
         g_renderQueue.enqueue(cmd);
 
         SetDefaultViewport(device, renderTarget);
+    }
+    else
+    {
+        // Multiple targets are not currently handled. Make sure any attempt to set them is nullptr.
+        assert(renderTarget == nullptr);
     }
 }
 
@@ -3499,7 +3503,6 @@ static void ProcSetRenderTarget(const RenderCommand& cmd)
 
 static void SetDepthStencilSurface(GuestDevice* device, GuestSurface* depthStencil) 
 {
-    // printf("SetDepthStencilSurface: %x\n", depthStencil);
     RenderCommand cmd;
     cmd.type = RenderCommandType::SetDepthStencilSurface;
     cmd.setDepthStencilSurface.depthStencil = depthStencil;


### PR DESCRIPTION
Setting render target to `nullptr` was being ignored because it causes crashes. Turns out the crashes are only because the game constantly sets targets 1-3 to null and they were all being treated as target 0. Simply checking if `index == 0` instead and allowing `nullptr` fixes depth-only rendering.

Fixes issue where shadow map rendering may be cut off due to smaller color target: https://github.com/ga2mer/MarathonRecomp/issues/29