### PR TITLE
Clean-up profiler window

### DIFF
--- a/MarathonRecomp/gpu/video.cpp
+++ b/MarathonRecomp/gpu/video.cpp
@@ -2700,7 +2700,7 @@ static void DrawProfiler()
 
         if (g_userHeap.heap != nullptr && g_userHeap.physicalHeap != nullptr)
         {
-            if (ImGui::CollapsingHeader("Memory"))
+            if (ImGui::CollapsingHeader("Memory", ImGuiTreeNodeFlags_DefaultOpen))
             {
                 O1HeapDiagnostics diagnostics, physicalDiagnostics;
                 {
@@ -2722,7 +2722,7 @@ static void DrawProfiler()
             }
         }
 
-        if (ImGui::CollapsingHeader("GPU"))
+        if (ImGui::CollapsingHeader("GPU", ImGuiTreeNodeFlags_DefaultOpen))
         {
             std::string backend;
 


### PR DESCRIPTION
This PR cleans up the profiler window and removes some leftover Unleashed Recompiled metrics.

### Before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/b4aabc54-2313-4554-b31a-27b81e8d8938" />

### After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/d0974d92-4ce9-4e94-b918-95c28db32510" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/eee3d21f-5e5f-4064-ba61-b681ba06dd75" />
