### PR TITLE
Update build instructions for macOS

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -51,7 +51,7 @@ You can also find the equivalent packages for your preferred distro.
 > This list may not be comprehensive for your particular distro and you may be required to install additional packages, should an error occur during configuration.
 
 ### macOS
-You will need to install the latest Xcode or Xcode Command Line Tools from Apple.
+You will need to install the latest Xcode from Apple.
 
 The following commands will install additional required dependencies, depending on which package manager you use.
 


### PR DESCRIPTION
It appears that Metal is required in order to build, and unless I'm missing something, it's not possible to get Metal without installing full-fat Xcode. 

I swore I used to be able to build with just the command-line tools--I wonder if something changed.

```
[489/911] Generating /Users/james/Developer/MarathonRecomp/MarathonRecompLib/shader/shader_cache.cpp Recompiling shaders with 10 threads
xcrun: error: unable to find utility "metal", not a developer tool or in PATH'
```