### PR TITLE
Use UPLOAD instead of DEFAULT Heap for iGPU compatiblity

### DIFF
--- a/MarathonRecomp/gpu/video.cpp
+++ b/MarathonRecomp/gpu/video.cpp
@@ -3515,7 +3515,7 @@ static GuestTexture* CreateTexture(uint32_t width, uint32_t height, uint32_t dep
 
 static RenderHeapType GetBufferHeapType()
 {
-    return g_capabilities.gpuUploadHeap ? RenderHeapType::GPU_UPLOAD : RenderHeapType::DEFAULT;
+    return g_capabilities.gpuUploadHeap && !g_capabilities.uma ? RenderHeapType::GPU_UPLOAD : RenderHeapType::UPLOAD;
 }
 
 static GuestBuffer* CreateVertexBuffer(uint32_t length) 


### PR DESCRIPTION
Fixes https://github.com/sonicnext-dev/MarathonRecomp/issues/220

I am not a graphics programmer, just ran into this and reproduced it on UnleashedRecomp and this project.
I am not sure if there is a performance penalty using RenderHeapType::UPLOAD vs RenderHeapType::DEFAULT, so maybe devices that are non-uma and don't have gpuUpload capability should still fallback to RenderHeapType::DEFAULT.