### PR TITLE
Fix MARATHON_RECOMP define in compile_shader

### DIFF
--- a/MarathonRecomp/CMakeLists.txt
+++ b/MarathonRecomp/CMakeLists.txt
@@ -446,7 +446,7 @@ function(compile_shader FILE_PATH TARGET_NAME)
     if (MARATHON_RECOMP_METAL)
         add_custom_command(
                 OUTPUT ${MSL_FILE_PATH}.ir
-                COMMAND ${XCRUN_TOOL} -sdk macosx metal -o ${MSL_FILE_PATH}.ir -c ${MSL_FILE_PATH} -D__air__ -frecord-sources -gline-tables-only
+                COMMAND ${XCRUN_TOOL} -sdk macosx metal -o ${MSL_FILE_PATH}.ir -c ${MSL_FILE_PATH} -D__air__ -DMARATHON_RECOMP -frecord-sources -gline-tables-only
                 DEPENDS ${MSL_FILE_PATH}
         )
         add_custom_command(
@@ -459,25 +459,25 @@ function(compile_shader FILE_PATH TARGET_NAME)
     if (MARATHON_RECOMP_D3D12)
         add_custom_command(
             OUTPUT ${HLSL_FILE_PATH}.dxil.h
-            COMMAND ${DIRECTX_DXC_TOOL} -T ${TARGET_NAME} -HV 2021 -all-resources-bound -Wno-ignored-attributes -E shaderMain -Fh ${HLSL_FILE_PATH}.dxil.h ${HLSL_FILE_PATH} -Vn g_${HLSL_NAME}_dxil
+            COMMAND ${DIRECTX_DXC_TOOL} -T ${TARGET_NAME} -HV 2021 -all-resources-bound -Wno-ignored-attributes -DMARATHON_RECOMP -E shaderMain -Fh ${HLSL_FILE_PATH}.dxil.h ${HLSL_FILE_PATH} -Vn g_${HLSL_NAME}_dxil
             DEPENDS ${HLSL_FILE_PATH}
         )
         target_sources(MarathonRecomp PRIVATE ${HLSL_FILE_PATH}.dxil.h)
     endif()
     add_custom_command(
         OUTPUT ${HLSL_FILE_PATH}.spirv.h
-        COMMAND ${DIRECTX_DXC_TOOL} -T ${TARGET_NAME} -HV 2021 -all-resources-bound -spirv -fvk-use-dx-layout ${ARGN} -E shaderMain -Fh ${HLSL_FILE_PATH}.spirv.h ${HLSL_FILE_PATH} -Vn g_${HLSL_NAME}_spirv
+        COMMAND ${DIRECTX_DXC_TOOL} -T ${TARGET_NAME} -HV 2021 -all-resources-bound -spirv -fvk-use-dx-layout ${ARGN} -DMARATHON_RECOMP -E shaderMain -Fh ${HLSL_FILE_PATH}.spirv.h ${HLSL_FILE_PATH} -Vn g_${HLSL_NAME}_spirv
         DEPENDS ${HLSL_FILE_PATH}
     )
     target_sources(MarathonRecomp PRIVATE ${HLSL_FILE_PATH}.spirv.h)
 endfunction()
 
 function(compile_vertex_shader FILE_PATH)
-    compile_shader(${FILE_PATH} vs_6_0 -fvk-invert-y -DMARATHON_RECOMP)
+    compile_shader(${FILE_PATH} vs_6_0 -fvk-invert-y)
 endfunction()
 
 function(compile_pixel_shader FILE_PATH)
-    compile_shader(${FILE_PATH} ps_6_0 -DMARATHON_RECOMP)
+    compile_shader(${FILE_PATH} ps_6_0)
 endfunction()
 
 compile_pixel_shader(blend_color_alpha_ps)

--- a/MarathonRecomp/gpu/shader/hlsl/conditional_survey_ps.hlsl
+++ b/MarathonRecomp/gpu/shader/hlsl/conditional_survey_ps.hlsl
@@ -1,5 +1,14 @@
 #include "../../../../tools/XenosRecomp/XenosRecomp/shader_common.h"
 
+#ifndef __spirv__
+
+cbuffer SharedConstants : register(b2, space4)
+{
+	DEFINE_SHARED_CONSTANTS();
+};
+
+#endif
+
 [earlydepthstencil]
 float4 shaderMain() : SV_Target
 {


### PR DESCRIPTION
`ARGN` is only being used by SPIR-V compile. `-fvk-invert-y` for vertex shaders should only be for SPIR-V, so just move the `-DMARATHON_RECOMP` into the function.

Fixes Windows build.